### PR TITLE
Set api-version to 1.13

### DIFF
--- a/resources/plugin.yml
+++ b/resources/plugin.yml
@@ -1,5 +1,6 @@
 name: NameMCHook
 version: 0.3
+api-version: 1.13
 main: me.abhi.hook.Hook
 author: abhi
 commands:


### PR DESCRIPTION
This will avoid initializing old material on newer servers (1.12.2 and old is not affected)